### PR TITLE
[FEATURE] Added support for overriding #max_attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [develop](https://github.com/adhearsion/adhearsion-ivr)
   * Feature: Added support for defining alternative prompt resolution algorithms by overriding `#prompts`
+  * Feature: Added support for overriding `#max_attempts`
 
 # [v0.1.0](https://github.com/adhearsion/adhearsion-ivr/compare/2c7ff73f5d6471be23e291c7d6c7b61d0128e09a...0.1.0) - [2014-03-12](https://rubygems.org/gems/adhearsion-ivr/versions/0.1.0)
   * Initial release

--- a/lib/adhearsion-ivr/ivr_controller.rb
+++ b/lib/adhearsion-ivr/ivr_controller.rb
@@ -103,12 +103,16 @@ module Adhearsion
       self.class.prompts
     end
 
+    def max_attempts
+      self.class.max_attempts
+    end
+
     def increment_errors
       @errors += 1
     end
 
     def continue?
-      @errors < self.class.max_attempts
+      @errors < max_attempts
     end
 
     def completion_callback

--- a/spec/adhearsion-ivr/ivr_controller_spec.rb
+++ b/spec/adhearsion-ivr/ivr_controller_spec.rb
@@ -428,5 +428,25 @@ describe Adhearsion::IVRController do
         end
       end
     end
+
+    context "when overriding max_attempts" do
+      let(:max_attempts_number) { 2 }
+
+      before do
+        max_attempts_number = self.max_attempts_number
+        controller_class.send :define_method, :max_attempts do
+          max_attempts_number
+        end
+      end
+
+      context "with a different number of attempts than the default and failed input" do
+        it "plays the apology announcement after receiving the correct number of failed inputs" do
+          controller.should_receive(:ask).once.with(expected_prompts[0], grammar: expected_grammar, mode: :voice).and_return noinput_result
+          controller.should_receive(:ask).once.with(expected_prompts[1], grammar: expected_grammar, mode: :voice).and_return noinput_result
+          controller.should_receive(:say).once.with apology_announcement
+          controller.run
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This allows subclasses to override `#max_attempts` in a similar fashion to overriding the prompts.
